### PR TITLE
Set exit code

### DIFF
--- a/dotnet-decode-base64.sln.DotSettings
+++ b/dotnet-decode-base64.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gabo/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/dotnet-decode-base64/Base64Decoder.cs
+++ b/src/dotnet-decode-base64/Base64Decoder.cs
@@ -1,4 +1,4 @@
-namespace DotNet.DecodeBase64;
+namespace Gabo.DotNet.DecodeBase64;
 
 public static class Base64Decoder
 {

--- a/src/dotnet-decode-base64/IConsole.cs
+++ b/src/dotnet-decode-base64/IConsole.cs
@@ -1,4 +1,4 @@
-namespace DotNet.DecodeBase64;
+namespace Gabo.DotNet.DecodeBase64;
 
 internal interface IConsole
 {

--- a/src/dotnet-decode-base64/IConsole.cs
+++ b/src/dotnet-decode-base64/IConsole.cs
@@ -1,0 +1,8 @@
+namespace DotNet.DecodeBase64;
+
+internal interface IConsole
+{
+    void WriteFancyLine(string line);
+    void WriteBoringLine(string line);
+    void WriteErrorLine(string line);
+}

--- a/src/dotnet-decode-base64/NonThreadSafeConsole.cs
+++ b/src/dotnet-decode-base64/NonThreadSafeConsole.cs
@@ -1,0 +1,26 @@
+namespace DotNet.DecodeBase64;
+
+internal class NonThreadSafeConsole : IConsole
+{
+    public void WriteFancyLine(string line)
+    {
+        WriteColoredLine(ConsoleColor.Green, line);
+    }
+
+    public void WriteBoringLine(string line)
+    {
+        Console.WriteLine(line);
+    }
+
+    public void WriteErrorLine(string line)
+    {
+        WriteColoredLine(ConsoleColor.Red, line);
+    }
+
+    private static void WriteColoredLine(ConsoleColor color, string line)
+    {
+        Console.ForegroundColor = color;
+        Console.WriteLine(line);
+        Console.ResetColor();
+    }
+}

--- a/src/dotnet-decode-base64/NonThreadSafeConsole.cs
+++ b/src/dotnet-decode-base64/NonThreadSafeConsole.cs
@@ -1,4 +1,4 @@
-namespace DotNet.DecodeBase64;
+namespace Gabo.DotNet.DecodeBase64;
 
 internal class NonThreadSafeConsole : IConsole
 {

--- a/src/dotnet-decode-base64/Program.cs
+++ b/src/dotnet-decode-base64/Program.cs
@@ -1,33 +1,35 @@
 namespace DotNet.DecodeBase64;
 
-internal class Program
+internal static class Program
 {
-    private static void Main(string[] args)
+    internal const int SuccessExitCode = 0;
+    internal const int FailureExitCode = 1;
+
+    internal static IConsole AbstractedConsole;
+
+    internal static int Main(string[] args)
     {
+        AbstractedConsole ??= new NonThreadSafeConsole();
+
         if (args.Length != 1)
         {
-            Console.WriteLine("A single argument should be provided:");
-            Console.WriteLine("dotnet decode-base64 SGVsbG8gV29ybGQh");
-            return;
+            AbstractedConsole.WriteBoringLine("A single argument should be provided:");
+            AbstractedConsole.WriteBoringLine("dotnet decode-base64 SGVsbG8gV29ybGQh");
+            return FailureExitCode;
         }
 
         try
         {
             var decodedString = Base64Decoder.Decode(args[0]);
 
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine("Decoded string:");
-            Console.ResetColor();
-            Console.WriteLine(decodedString);
+            AbstractedConsole.WriteFancyLine("Decoded string:");
+            AbstractedConsole.WriteBoringLine(decodedString);
+            return SuccessExitCode;
         }
         catch (FormatException e)
         {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine(e.Message);
-        }
-        finally
-        {
-            Console.ResetColor();
+            AbstractedConsole.WriteErrorLine(e.Message);
+            return FailureExitCode;
         }
     }
 }

--- a/src/dotnet-decode-base64/Program.cs
+++ b/src/dotnet-decode-base64/Program.cs
@@ -1,4 +1,4 @@
-namespace DotNet.DecodeBase64;
+namespace Gabo.DotNet.DecodeBase64;
 
 internal static class Program
 {

--- a/src/dotnet-decode-base64/dotnet-decode-base64.csproj
+++ b/src/dotnet-decode-base64/dotnet-decode-base64.csproj
@@ -22,6 +22,9 @@
     <NoWarn>CS7035</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="DotNet.DecodeBase64.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <Using Include="System.Text" />
   </ItemGroup>
   <ItemGroup>
@@ -31,6 +34,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-decode-base64/dotnet-decode-base64.csproj
+++ b/src/dotnet-decode-base64/dotnet-decode-base64.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'True'">true</ContinuousIntegrationBuild>
-    <RootNamespace>DotNet.DecodeBase64</RootNamespace>
+    <RootNamespace>Gabo.DotNet.DecodeBase64</RootNamespace>
     <PackAsTool>true</PackAsTool>
     <PackageId>dotnet-decode-base64</PackageId>
     <Authors>Gabriel Weyer</Authors>
@@ -22,7 +22,7 @@
     <NoWarn>CS7035</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="DotNet.DecodeBase64.Tests" />
+    <InternalsVisibleTo Include="Gabo.DotNet.DecodeBase64.Tests" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Text" />

--- a/tests/dotnet-decode-base64-tests/Base64DecoderTests.cs
+++ b/tests/dotnet-decode-base64-tests/Base64DecoderTests.cs
@@ -1,4 +1,4 @@
-namespace DotNet.DecodeBase64.Tests;
+namespace Gabo.DotNet.DecodeBase64.Tests;
 
 public class Base64DecoderTests
 {
@@ -13,7 +13,7 @@ public class Base64DecoderTests
         var actual = Base64Decoder.Decode(input);
 
         // Assert
-        Assert.Equal(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Theory]
@@ -25,7 +25,7 @@ public class Base64DecoderTests
         var actual = Base64Decoder.Decode(input);
 
         // Assert
-        Assert.Equal(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Theory]
@@ -37,6 +37,6 @@ public class Base64DecoderTests
         var actual = Base64Decoder.Decode(input);
 
         // Assert
-        Assert.Equal(expected, actual);
+        actual.Should().Be(expected);
     }
 }

--- a/tests/dotnet-decode-base64-tests/ProgramTests.cs
+++ b/tests/dotnet-decode-base64-tests/ProgramTests.cs
@@ -1,7 +1,4 @@
-using DotNet.DecodeBase64.Tests.TestInfrastructure;
-using FluentAssertions;
-
-namespace DotNet.DecodeBase64.Tests;
+namespace Gabo.DotNet.DecodeBase64.Tests;
 
 public class ProgramTests
 {

--- a/tests/dotnet-decode-base64-tests/ProgramTests.cs
+++ b/tests/dotnet-decode-base64-tests/ProgramTests.cs
@@ -1,0 +1,143 @@
+using DotNet.DecodeBase64.Tests.TestInfrastructure;
+using FluentAssertions;
+
+namespace DotNet.DecodeBase64.Tests;
+
+public class ProgramTests
+{
+    private readonly MockConsole _console;
+    private const string ValidBase64Input = "SGVsbG8gV29ybGQh";
+    private const string DecodedValidBase64Input = "Hello World!";
+    private const string InvalidBase64Input = "#";
+
+    public ProgramTests()
+    {
+        _console = new MockConsole();
+        Program.AbstractedConsole = _console;
+    }
+
+    [Fact]
+    public void GivenNoArgumentProvided_ThenDisplayInstructions()
+    {
+        // Arrange
+        var input = Array.Empty<string>();
+
+        // Act
+        Program.Main(input);
+
+        // Assert
+        var expectedLines = new List<ColoredLine>
+        {
+            new("A single argument should be provided:", MockConsole.BoringColor),
+            new("dotnet decode-base64 SGVsbG8gV29ybGQh", MockConsole.BoringColor)
+        };
+        _console.Lines.Should().BeEquivalentTo(expectedLines);
+    }
+
+    [Fact]
+    public void GivenNoArgumentProvided_ThenFailureExitCode()
+    {
+        // Arrange
+        var input = Array.Empty<string>();
+
+        // Act
+        var actualExitCode = Program.Main(input);
+
+        // Assert
+        actualExitCode.Should().Be(Program.FailureExitCode);
+    }
+
+    [Fact]
+    public void GivenMoreThanOneArgumentProvided_ThenDisplayInstructions()
+    {
+        // Arrange
+        var input = new[] { ValidBase64Input, ValidBase64Input };
+
+        // Act
+        Program.Main(input);
+
+        // Assert
+        var expectedLines = new List<ColoredLine>
+        {
+            new("A single argument should be provided:", MockConsole.BoringColor),
+            new("dotnet decode-base64 SGVsbG8gV29ybGQh", MockConsole.BoringColor)
+        };
+        _console.Lines.Should().BeEquivalentTo(expectedLines);
+    }
+
+    [Fact]
+    public void GivenMoreThanOneArgumentProvided_ThenFailureExitCode()
+    {
+        // Arrange
+        var input = new[] { ValidBase64Input, ValidBase64Input };
+
+        // Act
+        var actualExitCode = Program.Main(input);
+
+        // Assert
+        actualExitCode.Should().Be(Program.FailureExitCode);
+    }
+
+    [Fact]
+    public void GivenInvalidBase64Input_ThenDisplayErrorMessage()
+    {
+        // Arrange
+        var input = new[] { InvalidBase64Input };
+
+        // Act
+        Program.Main(input);
+
+        // Assert
+        const string errorMessage =
+            "The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.";
+        var expectedLines = new List<ColoredLine>
+        {
+            new(errorMessage, MockConsole.ErrorColor)
+        };
+        _console.Lines.Should().BeEquivalentTo(expectedLines);
+    }
+
+    [Fact]
+    public void GivenInvalidBase64Input_ThenFailureExitCode()
+    {
+        // Arrange
+        var input = new[] { InvalidBase64Input };
+
+        // Act
+        var actualExitCode = Program.Main(input);
+
+        // Assert
+        actualExitCode.Should().Be(Program.FailureExitCode);
+    }
+
+    [Fact]
+    public void GivenValidBase64Input_ThenDisplayDecodedInput()
+    {
+        // Arrange
+        var input = new[] { ValidBase64Input };
+
+        // Act
+        Program.Main(input);
+
+        // Assert
+        var expectedLines = new List<ColoredLine>
+        {
+            new("Decoded string:", MockConsole.FancyColor),
+            new(DecodedValidBase64Input, MockConsole.BoringColor)
+        };
+        _console.Lines.Should().BeEquivalentTo(expectedLines);
+    }
+
+    [Fact]
+    public void GivenValidBase64Input_ThenSuccessExitCode()
+    {
+        // Arrange
+        var input = new[] { ValidBase64Input };
+
+        // Act
+        var actualExitCode = Program.Main(input);
+
+        // Assert
+        actualExitCode.Should().Be(Program.SuccessExitCode);
+    }
+}

--- a/tests/dotnet-decode-base64-tests/TestInfrastructure/MockConsole.cs
+++ b/tests/dotnet-decode-base64-tests/TestInfrastructure/MockConsole.cs
@@ -1,0 +1,43 @@
+namespace DotNet.DecodeBase64.Tests.TestInfrastructure;
+
+internal class MockConsole : IConsole
+{
+    public const ConsoleColor FancyColor = ConsoleColor.Cyan;
+    public const ConsoleColor BoringColor = ConsoleColor.Yellow;
+    public const ConsoleColor ErrorColor = ConsoleColor.Magenta;
+    public IReadOnlyList<ColoredLine> Lines => _lines;
+
+    private readonly List<ColoredLine> _lines;
+
+    public MockConsole()
+    {
+        _lines = new List<ColoredLine>();
+    }
+
+    public void WriteFancyLine(string line)
+    {
+        _lines.Add(new ColoredLine(line, FancyColor));
+    }
+
+    public void WriteBoringLine(string line)
+    {
+        _lines.Add(new ColoredLine(line, BoringColor));
+    }
+
+    public void WriteErrorLine(string line)
+    {
+        _lines.Add(new ColoredLine(line, ErrorColor));
+    }
+}
+
+internal class ColoredLine
+{
+    public ColoredLine(string line, ConsoleColor color)
+    {
+        Line = line;
+        Color = color;
+    }
+
+    public ConsoleColor Color { get; }
+    public string Line { get; }
+}

--- a/tests/dotnet-decode-base64-tests/TestInfrastructure/MockConsole.cs
+++ b/tests/dotnet-decode-base64-tests/TestInfrastructure/MockConsole.cs
@@ -1,4 +1,4 @@
-namespace DotNet.DecodeBase64.Tests.TestInfrastructure;
+namespace Gabo.DotNet.DecodeBase64.Tests.TestInfrastructure;
 
 internal class MockConsole : IConsole
 {

--- a/tests/dotnet-decode-base64-tests/dotnet-decode-base64-tests.csproj
+++ b/tests/dotnet-decode-base64-tests/dotnet-decode-base64-tests.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>DotNet.DecodeBase64.Tests</RootNamespace>
+    <AssemblyName>DotNet.DecodeBase64.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
     <NoWarn>CS7035</NoWarn>
   </PropertyGroup>
@@ -18,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/dotnet-decode-base64-tests/dotnet-decode-base64-tests.csproj
+++ b/tests/dotnet-decode-base64-tests/dotnet-decode-base64-tests.csproj
@@ -4,13 +4,16 @@
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RootNamespace>DotNet.DecodeBase64.Tests</RootNamespace>
-    <AssemblyName>DotNet.DecodeBase64.Tests</AssemblyName>
+    <RootNamespace>Gabo.DotNet.DecodeBase64.Tests</RootNamespace>
+    <AssemblyName>Gabo.DotNet.DecodeBase64.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
     <NoWarn>CS7035</NoWarn>
   </PropertyGroup>
-  
+
   <ItemGroup>
+    <Using Include="FluentAssertions" />
+    <Using Include="Gabo.DotNet.DecodeBase64" />
+    <Using Include="Gabo.DotNet.DecodeBase64.Tests.TestInfrastructure" />
     <Using Include="Xunit" />
   </ItemGroup>
 


### PR DESCRIPTION
- Set exit code (`0` for success and `1` for failure)
- Prefix namespace with `Gabo` so that it doesn't start with `DotNet` (this way it doesn't look official)