### PR TITLE
Install .NET Core 3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v3
+        name: Install .NET Core 3.1
+        with:
+          dotnet-version: '3.1.x'
       - name: Build
         run: ./build.sh --package
       - name: Upload NuGet packages


### PR DESCRIPTION
.NET Core 3.1 is not installed on Ubuntu 22.0.