### PR TITLE
Split xUnit VS runner from dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,3 @@ updates:
         patterns:
           - xunit
           - xunit.analyzers
-          - xunit.runner.visualstudio

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,13 +9,13 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="xunit" Version="2.5.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageVersion Include="xunit.analyzers" Version="1.4.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <GlobalPackageReference Include="Meziantou.Analyzer" Version="2.0.102" />
     <GlobalPackageReference Include="AsyncFixer" Version="1.6.0" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" Condition="'$(TargetFramework)' == 'net6.0'" />
   </ItemGroup>
   <PropertyGroup>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>


### PR DESCRIPTION
So that I can ignore updates for .NET Core 3.1.